### PR TITLE
Fixed iOS Compile on MacOS - Boken Path Dependecy

### DIFF
--- a/share/config.py
+++ b/share/config.py
@@ -11,3 +11,4 @@ def configure(env):
 
 	if env['platform'] == "iphone":
 		env.Append(LINKFLAGS=['-ObjC'])
+		env.Append(CPPPATH=['#core'])


### PR DESCRIPTION
Hi @Shin-NiL with this change, the module can now be compiled for iOS.
Other than that, it would throw the error :

`[Initial build] Compiling ==> modules/share/register_types.cpp
modules/share/register_types.cpp:1:10:{1:10-1:35}: fatal error: 'version_generated.gen.h' file not found [1]
 #include <version_generated.gen.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
scons: *** [modules/share/register_types.iphone.debug.arm.o] Error 1
scons: building terminated because of errors.`