### PR TITLE
fix(ios): sourceRect for ipad device on ios 16+

### DIFF
--- a/share/ios/src/godotShare.mm
+++ b/share/ios/src/godotShare.mm
@@ -31,9 +31,11 @@ void GodotShare::shareText(const String &title, const String &subject, const Str
     //if iPad
     else {
         // Change Rect to position Popover
-	avc.modalPresentationStyle = UIModalPresentationPopover;
-	avc.popoverPresentationController.sourceView = root_controller.view;
-	[root_controller presentViewController:avc animated:YES completion:nil];
+        avc.modalPresentationStyle = UIModalPresentationPopover;
+        avc.popoverPresentationController.sourceView = root_controller.view;
+        avc.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(root_controller.view.bounds), CGRectGetMidY(root_controller.view.bounds),0,0);
+        avc.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection(0);
+        [root_controller presentViewController:avc animated:YES completion:nil];
     }
 }
 
@@ -55,9 +57,11 @@ void GodotShare::sharePic(const String &path, const String &title, const String 
     //if iPad
     else {
         // Change Rect to position Popover
-	avc.modalPresentationStyle = UIModalPresentationPopover;
-	avc.popoverPresentationController.sourceView = root_controller.view;
-	[root_controller presentViewController:avc animated:YES completion:nil];
+        avc.modalPresentationStyle = UIModalPresentationPopover;
+        avc.popoverPresentationController.sourceView = root_controller.view;
+        avc.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(root_controller.view.bounds), CGRectGetMidY(root_controller.view.bounds),0,0);
+        avc.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection(0);
+        [root_controller presentViewController:avc animated:YES completion:nil];
     }
 }
 


### PR DESCRIPTION
`sourceRect` is require on iPad device. If not define the popover will not work.

![Screenshot 2023-07-04 at 15 13 56](https://github.com/Shin-NiL/Godot-Share/assets/29815830/1b5c40a6-43c1-4c13-b3ae-a3987b876acd)
